### PR TITLE
prevent addon registration when Blender is run in background

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,8 @@ npie_btypes.configure("node_pie", auto_register=True)
 
 
 def register():
+    if bpy.app.background:
+        return 
     npie_btypes.register()
 
 


### PR DESCRIPTION
When Blender is run in the background in CLI (`blender -b`), don't register the addon.

Should fix #34