### PR TITLE
Skip executing the whole addon when run in background.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -11,6 +11,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import bpy
+import sys
+if bpy.app.background:
+    sys.exit(0)
 
 bl_info = {
     "name": "Node Pie 1.2.40",
@@ -30,8 +33,6 @@ npie_btypes.configure("node_pie", auto_register=True)
 
 
 def register():
-    if bpy.app.background:
-        return 
     npie_btypes.register()
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,7 @@
 import bpy
 import sys
 if bpy.app.background:
+    print(f"'{__name__}' skipped in background mode.")
     sys.exit(0)
 
 bl_info = {

--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,6 @@
 import bpy
 import sys
 if bpy.app.background:
-    print(f"'{__name__}' skipped in background mode.")
     sys.exit(0)
 
 bl_info = {


### PR DESCRIPTION
Instead of just avoiding registering the addon, explicitly exit with `sys.exit(0)` as soon as possible, preventing all possible errors related to running the add-on in background mode, and also saving from executing code that won't be used.


